### PR TITLE
Update fast_underscore.gemspec

### DIFF
--- a/fast_underscore.gemspec
+++ b/fast_underscore.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files =
     `git ls-files -z`.split("\x0")
-      .reject { |f| f.match(%r{^(test|spec|features)/}) }
+      .reject { |f| f.match(%r{^(test|spec|features|Gemfile.lock)/}) }
 
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
This gem is used in our application, unfortunately the AWS inspector finds every Gemfile.lock that is accidentally bundled with a gem and thinks we have installed those gems.

This PR should exclude Gemfile.lock from gem builds to stop CVE scanners picking this lock file up.